### PR TITLE
Fuller test set & metadata kwarg + README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The easiest way to install `ezlocaldb` is with pip
 
 ## Usage/Examples
 
-To work with `sqlalchemy` use `getEngine` to get an `engine` object for
-database access. The first argument to `getEngine` is the name of your
+### Quick Start
+To work with `sqlalchemy` use `get_engine` to get an `engine` object for
+database access. The first argument to `get_engine` is the name of your
 application, which is used to uniquely specify the database.
 
 ```python
@@ -29,7 +30,7 @@ from ezlocaldb import get_engine
 from sqlalchemy import Session
 
 # Get an sqlalchemy engine to use with sqlalchemy.Session
-engine = get_engine("MyAmazingApp")
+engine = get_engine(app_name="MyAmazingApp")
 
 with Session(engine) as session:
     # Now work with session to initalize database,
@@ -37,14 +38,55 @@ with Session(engine) as session:
     pass
 ```
 
-When you call `getEngine`, ezlocaldb checks to see if your database was created
+When you call `get_engine`, ezlocaldb checks to see if your database was created
 previously. If it wasn't it creates a new `sqlite` database. Either way, it
 returns an `engine` which can be used to access the database.
 
+### Removing or refreshing databases
 If you want to remove or refresh the database, use
 
 ```python
-from ezlocaldb import removeDatabase
+from ezlocaldb import remove_database, get_engine
 
-removeDatabase("MyAmazingApp")
+remove_database("MyAmazingApp")
+
+# To recreate the database (with no data in it) use
+engine = get_engine("MyAmazingApp")
 ```
+
+### Initializing the Schema
+Usually, getting tables and such setup is just a little tricky. When should you
+emit `CREATE TABLE` commands? Is everything in place? Did you just overwrite
+your data?
+
+With `ezlocaldb` you can pass a `sqlalchemy.MetaData` instance as a keyword
+argument to `get_engine`. If you're using the ORM, it's as simple as this:
+
+```python
+from sqlalchemy.orm import DeclarativeBase
+from ezlocaldb import get_engine
+
+class Base(DeclarativeBase):
+   pass
+
+# More ORM classes derived from Base
+# ...
+
+engine = get_engine('MyAmazingApp',metadata=Base.metadata)
+```
+
+If your database file hasn't been created, `get_engine` will `create_all` the
+tables, etc. represented in your ORM tree. If the file was previously created,
+the metadata argument is ignored. This way you can quickly get a database setup
+for orm operations, and not worry about accidentally overwritting all your data.
+
+If you make changes to your ORM structure, you can use `remove_database` from a
+repl or other function, and call `get_engine` with the `metadata` argument again,
+and the new database will reflect all your new structure.
+
+> **A not on migrations**.
+> Database migrations are a complicated subject. If you want to keep your data
+> while you revise your ORM structure or Database Schema, you're probably ready
+> to graduate to straight `SQLAlchemy`, and look at `Alembic`.
+
+### Thank You!

--- a/ezlocaldb/__init__.py
+++ b/ezlocaldb/__init__.py
@@ -40,14 +40,14 @@ def _setupDB(app_name: str, db_name: str) -> Tuple[Path, bool]:
     return db_path, freshDB
 
 
-def _getDBPath(app_name: str, db_name: str) -> Path:
+def _getDBPath(app_name: str, db_name: str = DEFAULT_NAME) -> Path:
     """Return DB Path, without creating any of the intermediate files/folders."""
     db_dir = Path(appdirs.user_data_dir(appname=app_name))
     db_path = db_dir / db_name
     return db_path
 
 
-def removeDatabase(app_name: str, db_name: str = DEFAULT_NAME) -> None:
+def remove_database(app_name: str, db_name: str = DEFAULT_NAME) -> None:
     """Remove database file.
 
     Also removes the data folder tree, if it is empty."""

--- a/ezlocaldb/__init__.py
+++ b/ezlocaldb/__init__.py
@@ -33,12 +33,18 @@ def _setupDB(app_name: str, db_name: str) -> Tuple[Path, bool]:
     If the file already exists, nothing is changed.
     Returns a Path object to the database"""
 
-    db_dir = Path(appdirs.user_data_dir(appname=app_name))
-    db_dir.mkdir(parents=True, exist_ok=True)
-    db_path = db_dir / db_name
+    db_path = _getDBPath(app_name, db_name)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     freshDB = ~db_path.exists()
     db_path.touch(exist_ok=True)
     return db_path, freshDB
+
+
+def _getDBPath(app_name: str, db_name: str) -> Path:
+    """Return DB Path, without creating any of the intermediate files/folders."""
+    db_dir = Path(appdirs.user_data_dir(appname=app_name))
+    db_path = db_dir / db_name
+    return db_path
 
 
 def removeDatabase(app_name: str, db_name: str = DEFAULT_NAME) -> None:
@@ -49,7 +55,7 @@ def removeDatabase(app_name: str, db_name: str = DEFAULT_NAME) -> None:
     for engine in _engineDict[app_name]:
         engine.dispose(close=True)
 
-    db_path = _setupDB(app_name, db_name)
+    db_path = _getDBPath(app_name, db_name)
     db_path.unlink(missing_ok=True)
     temp = db_path.parent
     try:

--- a/ezlocaldb/__init__.py
+++ b/ezlocaldb/__init__.py
@@ -1,19 +1,34 @@
 from pathlib import Path
+from typing import Optional, Tuple
+from collections import defaultdict
 
 import appdirs
-from sqlalchemy import Engine, create_engine as _create_engine
+from sqlalchemy import Engine, create_engine as _create_engine, MetaData
 
 DEFAULT_NAME = "Database.db"
 
+_engineDict = defaultdict(list)
 
-def get_engine(app_name: str, db_name: str = DEFAULT_NAME) -> Engine:
+
+def get_engine(
+    app_name: str,
+    db_name: str = DEFAULT_NAME,
+    metadata: Optional[MetaData] = None,
+    **kwargs,
+) -> Engine:
     """Return an SQlAlchemy Engine for a specific app"""
-    db_path = _setupDB(app_name, db_name)
-    engine = _create_engine(f"sqlite:///{str(db_path)}")
+    db_path, newDB = _setupDB(app_name, db_name)
+    engine = _create_engine(f"sqlite:///{str(db_path)}", **kwargs)
+
+    _engineDict[app_name].append(engine)
+
+    if metadata is not None and newDB:
+        metadata.create_all(engine)
+
     return engine
 
 
-def _setupDB(app_name: str, db_name: str) -> Path:
+def _setupDB(app_name: str, db_name: str) -> Tuple[Path, bool]:
     """Setup the database file in the appropriate location.
     If the file already exists, nothing is changed.
     Returns a Path object to the database"""
@@ -21,14 +36,19 @@ def _setupDB(app_name: str, db_name: str) -> Path:
     db_dir = Path(appdirs.user_data_dir(appname=app_name))
     db_dir.mkdir(parents=True, exist_ok=True)
     db_path = db_dir / db_name
+    freshDB = ~db_path.exists()
     db_path.touch(exist_ok=True)
-    return db_path
+    return db_path, freshDB
 
 
-def removeDatabase(app_name: str, db_name: str = DEFAULT_NAME):
+def removeDatabase(app_name: str, db_name: str = DEFAULT_NAME) -> None:
     """Remove database file.
 
     Also removes the data folder tree, if it is empty."""
+
+    for engine in _engineDict[app_name]:
+        engine.dispose(close=True)
+
     db_path = _setupDB(app_name, db_name)
     db_path.unlink(missing_ok=True)
     temp = db_path.parent

--- a/tests/test__init__.py
+++ b/tests/test__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest  # noqa: F401
 
 from sqlalchemy import Engine, MetaData
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
 
 import ezlocaldb as ezdb
 
@@ -11,50 +11,72 @@ appName = "MyAppName"
 dbName = "MyTestDatabase.db"
 
 
-def test_create_and_remove_db():
+def test_get_engine_and_remove_db():
     engine = ezdb.get_engine(appName)
     assert isinstance(engine, Engine)
+    ezdb.remove_database(appName)
+    dbPath = ezdb._getDBPath(appName)
+    assert not dbPath.exists()
 
 
 def test_db_path_setup_and_removal():
     dbPath, _ = ezdb._setupDB(appName, dbName)
     assert dbPath.exists()
-    ezdb.removeDatabase(appName, dbName)
+    ezdb.remove_database(appName, dbName)
     assert not dbPath.exists()
 
 
-@pytest.fixture
-def test_metadata():
-    class Base(DeclarativeBase):
-        pass
-
-    class TestObjects(Base):
-        __tablename__ = "TestingTable"
-        id: Mapped[int] = mapped_column(primary_key=True)
-        testfield: Mapped[str]
-        optfield: Mapped[Optional[str]]
-
-    return Base.metadata
+class Base(DeclarativeBase):
+    pass
 
 
-def test_create_wMetadata_and_delete(test_metadata):
+class TestObjects(Base):
+    __tablename__ = "TestingTable"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    testfield: Mapped[str]
+    optfield: Mapped[Optional[str]]
+
+
+def test_create_wMetadata_and_delete():
     """Test Database creationg with metadata emission, then DB removal"""
     # Test only works if database doesn't exist ahead of time.
-    ezdb.removeDatabase(appName, dbName)
+    ezdb.remove_database(appName, dbName)
     dbPath = ezdb._getDBPath(appName, dbName)
     assert not dbPath.exists()
 
-    eng = ezdb.get_engine("MyTestDatabase.db", metadata=test_metadata)
+    eng = ezdb.get_engine("MyTestDatabase.db", metadata=Base.metadata)
     newMetadata = MetaData()
     newMetadata.reflect(bind=eng)
     assert "TestingTable" in newMetadata.tables
     testingTable = newMetadata.tables["TestingTable"]
     assert "id" in testingTable.c
 
-    ezdb.removeDatabase(appName, dbName)
+    ezdb.remove_database(appName, dbName)
 
     assert not dbPath.exists()
 
     # Try using disposed engine and see what happens!
     newMetadata.create_all(eng)
     assert not dbPath.exists()
+
+
+def test_CRUD_and_multiple_engines():
+    ezdb.remove_database(appName)
+    eng1 = ezdb.get_engine(appName, metadata=Base.metadata)
+    eng2 = ezdb.get_engine(appName, metadata=Base.metadata)
+
+    with Session(eng1) as ses:
+        t1 = TestObjects(testfield="hello")
+        ses.add(t1)
+        ses.commit()
+
+    with Session(eng2) as ses:
+        t2 = ses.query(TestObjects).scalar()
+        assert t2.testfield == "hello"
+        ses.delete(t2)
+        ses.commit()
+
+    with Session(eng1) as ses:
+        assert ses.query(TestObjects).scalar() is None
+
+    ezdb.remove_database(appName)

--- a/tests/test__init__.py
+++ b/tests/test__init__.py
@@ -1,20 +1,60 @@
+from typing import Optional
+
 import pytest  # noqa: F401
 
-from sqlalchemy import Engine
+from sqlalchemy import Engine, MetaData
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 import ezlocaldb as ezdb
 
-appname = "MyAppName"
+appName = "MyAppName"
+dbName = "MyTestDatabase.db"
 
 
 def test_create_and_remove_db():
-    engine = ezdb.get_engine(appname)
+    engine = ezdb.get_engine(appName)
     assert isinstance(engine, Engine)
 
 
 def test_db_path_setup_and_removal():
-    dbName = "Database.db"
-    dbPath = ezdb._setupDB(appname, dbName)
+    dbPath, _ = ezdb._setupDB(appName, dbName)
     assert dbPath.exists()
-    ezdb.removeDatabase(appname, dbName)
+    ezdb.removeDatabase(appName, dbName)
+    assert not dbPath.exists()
+
+
+@pytest.fixture
+def test_metadata():
+    class Base(DeclarativeBase):
+        pass
+
+    class TestObjects(Base):
+        __tablename__ = "TestingTable"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        testfield: Mapped[str]
+        optfield: Mapped[Optional[str]]
+
+    return Base.metadata
+
+
+def test_create_wMetadata_and_delete(test_metadata):
+    """Test Database creationg with metadata emission, then DB removal"""
+    # Test only works if database doesn't exist ahead of time.
+    ezdb.removeDatabase(appName, dbName)
+    dbPath = ezdb._getDBPath(appName, dbName)
+    assert not dbPath.exists()
+
+    eng = ezdb.get_engine("MyTestDatabase.db", metadata=test_metadata)
+    newMetadata = MetaData()
+    newMetadata.reflect(bind=eng)
+    assert "TestingTable" in newMetadata.tables
+    testingTable = newMetadata.tables["TestingTable"]
+    assert "id" in testingTable.c
+
+    ezdb.removeDatabase(appName, dbName)
+
+    assert not dbPath.exists()
+
+    # Try using disposed engine and see what happens!
+    newMetadata.create_all(eng)
     assert not dbPath.exists()


### PR DESCRIPTION
Added better testing with basic CRUD operation (or at least CRD).
Added metadata kwarg to get_engine to allow simple database initialization.
Renamed removeDatabase to remove_database, to match get_engine name structure.

I'm making a (questionable) intentional design decision to use snake case for external functions, and lowerCamelCase for internal functions. This is because sqlalchemy tends to use snake case (so the external bits match that), but I prefer the condensed style of CamelCase. Sorry if this bugs you. Please politely tell me I'm wrong; I really am willing to change these things.